### PR TITLE
Components: Fix compilation issue: List react-router as peer dependency

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v3.0.0 Breaking changes
+
+- Fixed bug introduced in `v2.1.0`: Added missing peer dependency `react-router`
+
 ## v2.0.0 Breaking changes
 
 - Changed `localeName` prop of `Logo` component:

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@goodhood/components",
-  "version": "2.1.0",
+  "version": "2.1.0-beta.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@babel/runtime": {
-      "version": "7.11.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-      "integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
+      "version": "7.12.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
+      "integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
       "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
@@ -1105,12 +1105,12 @@
       }
     },
     "mini-create-react-context": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.4.0.tgz",
-      "integrity": "sha512-b0TytUgFSbgFJGzJqXPKCFCBWigAjpjo+Fl7Vf7ZbKRDptszpppKxXH6DRXEABZ/gcEQczeb0iZ7JvL8e8jjCA==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.4.1.tgz",
+      "integrity": "sha512-YWCYEmd5CQeHGSAKrYvXgmzzkrvssZcuuQDDeqkT+PziKGMgE+0MCCtcKbROzocGBG1meBLl2FotlRwf4gAzbQ==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.5.5",
+        "@babel/runtime": "^7.12.1",
         "tiny-warning": "^1.0.3"
       }
     },

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -11,7 +11,7 @@
   "bugs": {
     "url": "https://github.com/goodhood-eu/goodhood/issues"
   },
-  "version": "2.1.0",
+  "version": "3.0.0",
   "module": "lib/index.esm.js",
   "main": "lib/index.js",
   "sideEffects": false,
@@ -53,6 +53,7 @@
   "peerDependencies": {
     "nebenan-form": "^8.5.2",
     "nebenan-helpers": "^4.2.0",
+    "react-router": "^5.2.0",
     "lodash": "^4.17.20",
     "nebenan-react-hocs": "^5.9.0",
     "react": "^16.13.1",


### PR DESCRIPTION
```
Error [ERR_REQUIRE_ESM] [ERR_REQUIRE_ESM]: Must use import to load ES Module: /var/www/releases/20201124104853/node_modules/@babel/runtime/helpers/esm/inheritsLoose.js
require() of ES modules is not supported.
require() of /var/www/releases/20201124104853/node_modules/@babel/runtime/helpers/esm/inheritsLoose.js from /var/www/releases/20201124104853/node_modules/@goodhood/components/lib/index.js is an ES module file as it is a .js file whose nearest parent package.json contains "type": "module" which defines all .js files in that package scope as ES modules.
Instead rename inheritsLoose.js to end in .cjs, change the requiring code to use import(), or remove "type": "module" from /var/www/releases/20201124104853/node_modules/@babel/runtime/helpers/esm/package.json.

    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1080:13)
    at Module.load (internal/modules/cjs/loader.js:928:32)
    at Function.Module._load (internal/modules/cjs/loader.js:769:14)
    at Module.require (internal/modules/cjs/loader.js:952:19)
    at require (internal/modules/cjs/helpers.js:88:18)
    at Object.<anonymous> (/var/www/releases/20201124104853/node_modules/@goodhood/components/lib/index.js:10:22)
    at Module._compile (internal/modules/cjs/loader.js:1063:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1092:10)
    at Module.load (internal/modules/cjs/loader.js:928:32)
    at Function.Module._load (internal/modules/cjs/loader.js:769:14)
```

Components CJS bundle contained references to babel esm helpers because `react-router` wasn't marked as external in `rollup`. `react-router` does not support compiling their esm bundle to cjs because they are using `["@babel/transform-runtime", { useESModules: true }]`.

The fix is pretty simple, we forgot to add `react-router` as a peer dep (https://github.com/goodhood-eu/goodhood/pull/53).