### PR TITLE
Add theme prop to LinkHeader

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -11,7 +11,7 @@
   "bugs": {
     "url": "https://github.com/goodhood-eu/goodhood/issues"
   },
-  "version": "2.7.0",
+  "version": "2.8.0",
   "module": "lib/index.esm.js",
   "main": "lib/index.js",
   "sideEffects": false,

--- a/packages/components/src/link_header/default_theme.module.scss
+++ b/packages/components/src/link_header/default_theme.module.scss
@@ -1,0 +1,5 @@
+@import "~nebenan-ui-kit";
+
+.navigation {
+  color: $color-gray-02;
+}

--- a/packages/components/src/link_header/index.jsx
+++ b/packages/components/src/link_header/index.jsx
@@ -4,6 +4,9 @@ import { Link } from 'react-router-dom';
 import ArrowLeftIcon from '@goodhood/icons/lib/16x16/arrow_left';
 import ArrowRightIcon from '@goodhood/icons/lib/16x16/arrow_right';
 import styles from './index.module.scss';
+import defaultTheme from './default_theme.module.scss';
+
+export { default as LinkHeaderLinkTheme } from './link_theme';
 
 const LinkHeader = ({
   children,
@@ -12,6 +15,7 @@ const LinkHeader = ({
   action,
   reversed,
   className: passedClassName,
+  theme = defaultTheme,
   ...cleanProps
 }) => {
   const isClickable = to || onClick;
@@ -26,9 +30,9 @@ const LinkHeader = ({
     const Icon = reversed ? ArrowLeftIcon : ArrowRightIcon;
 
     icon = (
-      <div className={styles.navigation}>
+      <div className={clsx(styles.navigation, theme.navigation)}>
         {action && <span className={styles.action}>{action}</span>}
-        <Icon className={styles.icon} />
+        <Icon className={clsx(styles.icon, theme.icon)} />
       </div>
     );
   }
@@ -54,6 +58,7 @@ LinkHeader.propTypes = {
   reversed: PropTypes.bool,
   children: PropTypes.node,
   action: PropTypes.node,
+  theme: PropTypes.object,
 };
 
 export default LinkHeader;

--- a/packages/components/src/link_header/index.module.scss
+++ b/packages/components/src/link_header/index.module.scss
@@ -29,8 +29,6 @@
   grid-template-columns: 1fr auto;
   flex: 0 0 auto;
   align-items: center;
-
-  color: $color-gray-02;
 }
 
 .isReversed .navigation {

--- a/packages/components/src/link_header/index.stories.jsx
+++ b/packages/components/src/link_header/index.stories.jsx
@@ -1,7 +1,7 @@
-import { boolean, text, withKnobs } from '@storybook/addon-knobs';
+import { boolean, select, text, withKnobs } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
 import { MemoryRouter } from 'react-router';
-import LinkHeader from './index';
+import LinkHeader, { LinkHeaderLinkTheme } from './index';
 
 export default { title: 'LinkHeader', component: LinkHeader, decorators: [withKnobs] };
 
@@ -11,6 +11,7 @@ export const WithRouter = () => (
       reversed={boolean('reversed', undefined)}
       action={text('action', undefined)}
       to={text('to', '/')}
+      theme={select('theme', { default: undefined, LinkHeaderLinkTheme }, undefined)}
     >
       <h3>Header</h3>
       Content!
@@ -23,6 +24,7 @@ export const WithOnClick = () => (
     reversed={boolean('reversed', undefined)}
     action={text('action', undefined)}
     onClick={action('onClick')}
+    theme={select('theme', { default: undefined, LinkHeaderLinkTheme }, undefined)}
   >
     <h3>Header</h3>
     Content!
@@ -40,6 +42,7 @@ export const WithActionNode = () => (
   <LinkHeader
     onClick={action('onClick')}
     action={<span className="ui-link">Check it out</span>}
+    theme={select('theme', { default: undefined, LinkHeaderLinkTheme }, undefined)}
   >
     <h3>Header HeaderHeader HeaderHeader HeaderHeader Header    Header Header </h3>
     Content!

--- a/packages/components/src/link_header/link_theme.jsx
+++ b/packages/components/src/link_header/link_theme.jsx
@@ -1,0 +1,6 @@
+import styles from './link_theme.module.scss';
+
+export default {
+  navigation: 'ui-link',
+  ...styles,
+};

--- a/packages/components/src/link_header/link_theme.module.scss
+++ b/packages/components/src/link_header/link_theme.module.scss
@@ -1,0 +1,6 @@
+@import "~nebenan-ui-kit";
+
+.icon {
+  width: 12px;
+  height: auto;
+}


### PR DESCRIPTION
I am not really confident into this PR. It's hard to get the design team to generalize stuff.
https://nebenan.slack.com/archives/C01A18L64TV/p1611161946040700?thread_ts=1611153894.038300&cid=C01A18L64TV

Looks like this 'theme' may be used again in the future. I don't want to create a new component that work like this one but only with minor style differences