### PR TITLE
Migrate outside-clicks to eventproxy

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -13,12 +13,6 @@
         "regenerator-runtime": "^0.13.4"
       }
     },
-    "@goodhood/icons": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@goodhood/icons/-/icons-1.5.0.tgz",
-      "integrity": "sha512-EGxcJPf7JWYaxhALf82FfPBlCMESVZ4ZDvAPeOXTS1KhJdYGzTyHny23icZkeLlUeboivegCxP/rXd6DE7V90A==",
-      "dev": true
-    },
     "@popperjs/core": {
       "version": "2.5.4",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.5.4.tgz",
@@ -1108,9 +1102,9 @@
       }
     },
     "nebenan-helpers": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/nebenan-helpers/-/nebenan-helpers-4.5.0.tgz",
-      "integrity": "sha512-Zo55iTGRAM0kNc4KJcVGy/PS55GxWPYkEq0PNlKRr6Qlm6HqmZHDJhhjWYAvCQxJAwThYCdzBevd4HQHkwvx2A==",
+      "version": "4.6.0-beta.0",
+      "resolved": "https://registry.npmjs.org/nebenan-helpers/-/nebenan-helpers-4.6.0-beta.0.tgz",
+      "integrity": "sha512-SYk2rS4g4r7+curAiFxGmdBZDfSONAQjomzp94dzG505KtnmJmRnbZ69pb5B75ZGO88VNhqzuzxm7CakoUSF5w==",
       "dev": true
     },
     "nebenan-react-datepicker": {

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@goodhood/components",
-  "version": "2.6.0",
+  "version": "2.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -12,12 +12,6 @@
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
-    },
-    "@goodhood/icons": {
-      "version": "1.5.0-beta.0",
-      "resolved": "https://registry.npmjs.org/@goodhood/icons/-/icons-1.5.0-beta.0.tgz",
-      "integrity": "sha512-kiMMRmv5CmL6lJyl9YZR3vtXYu81DxIKJ3DO3WrHFGhkUWVNCY82G0thKiROjK+hg4aqkdyQAj9X/9+QIrSWKA==",
-      "dev": true
     },
     "@popperjs/core": {
       "version": "2.5.4",
@@ -1108,9 +1102,9 @@
       }
     },
     "nebenan-helpers": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/nebenan-helpers/-/nebenan-helpers-4.5.0.tgz",
-      "integrity": "sha512-Zo55iTGRAM0kNc4KJcVGy/PS55GxWPYkEq0PNlKRr6Qlm6HqmZHDJhhjWYAvCQxJAwThYCdzBevd4HQHkwvx2A==",
+      "version": "4.6.0-beta.0",
+      "resolved": "https://registry.npmjs.org/nebenan-helpers/-/nebenan-helpers-4.6.0-beta.0.tgz",
+      "integrity": "sha512-SYk2rS4g4r7+curAiFxGmdBZDfSONAQjomzp94dzG505KtnmJmRnbZ69pb5B75ZGO88VNhqzuzxm7CakoUSF5w==",
       "dev": true
     },
     "nebenan-react-datepicker": {

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1102,9 +1102,9 @@
       }
     },
     "nebenan-helpers": {
-      "version": "4.6.0-beta.0",
-      "resolved": "https://registry.npmjs.org/nebenan-helpers/-/nebenan-helpers-4.6.0-beta.0.tgz",
-      "integrity": "sha512-SYk2rS4g4r7+curAiFxGmdBZDfSONAQjomzp94dzG505KtnmJmRnbZ69pb5B75ZGO88VNhqzuzxm7CakoUSF5w==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/nebenan-helpers/-/nebenan-helpers-4.6.0.tgz",
+      "integrity": "sha512-g4/o5LfEzRtyZFdbQj7mKYWpqv5zrvCkGuJ+X0RxEQTmcV/jbQDkEvguKBRruih/Pv2mrwSwSrXl52V5i6krTg==",
       "dev": true
     },
     "nebenan-react-datepicker": {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -29,7 +29,7 @@
     "date-fns": "^2.16.1",
     "lodash": "^4.17.20",
     "nebenan-form": "^8.9.0",
-    "nebenan-helpers": "^4.5.0",
+    "nebenan-helpers": "^4.6.0-beta.0",
     "nebenan-react-hocs": "^7.1.0",
     "nebenan-ui-kit": "^4.15.0",
     "node-sass-glob-importer": "^5.3.2",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -11,7 +11,7 @@
   "bugs": {
     "url": "https://github.com/goodhood-eu/goodhood/issues"
   },
-  "version": "2.9.0",
+  "version": "2.9.1",
   "module": "lib/index.esm.js",
   "main": "lib/index.js",
   "sideEffects": false,

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -29,7 +29,7 @@
     "date-fns": "^2.16.1",
     "lodash": "^4.17.20",
     "nebenan-form": "^8.9.0",
-    "nebenan-helpers": "^4.6.0-beta.0",
+    "nebenan-helpers": "^4.6.0",
     "nebenan-react-hocs": "^7.1.0",
     "nebenan-ui-kit": "^4.15.0",
     "node-sass-glob-importer": "^5.3.2",
@@ -54,7 +54,7 @@
   },
   "peerDependencies": {
     "nebenan-form": "^8.9.0",
-    "nebenan-helpers": "^4.5.0",
+    "nebenan-helpers": "^4.6.0",
     "lodash": "^4.17.20",
     "nebenan-react-hocs": "^7.1.0",
     "react": "^16.14.0 || ^17.0.1",

--- a/packages/components/src/feature_alert/hooks.jsx
+++ b/packages/components/src/feature_alert/hooks.jsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import keymanager from 'nebenan-helpers/lib/keymanager';
+import eventproxy from 'nebenan-helpers/lib/eventproxy';
 import { invoke } from 'nebenan-helpers/lib/utils';
 import { TOOLTIP_TRIGGER_DELAYED, TOOLTIP_DELAY_TIMEOUT } from '../base_tooltip';
 
@@ -12,9 +13,8 @@ export const useOutsideClick = (ref, callback, disabled) => useEffect(() => {
     if (!ref.current) return;
     if (!ref.current.contains(event.target)) invoke(callback, event);
   };
-  document.addEventListener('click', handler);
 
-  return () => document.removeEventListener('click', handler);
+  return eventproxy('click', handler);
 }, [callback]);
 
 export const useDelayedOpen = (trigger, wasActiveOnce, callback) => useEffect(() => {


### PR DESCRIPTION
eventproxy now handles the react 17 event propagation issue

