### PR TITLE
Components: Raise CookieBanner to a higher z-index layer

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -22,7 +22,7 @@
         "nebenan-form": "^9.0.0",
         "nebenan-helpers": "^5.0.0",
         "nebenan-react-hocs": "^8.0.0",
-        "nebenan-ui-kit": "^5.0.1",
+        "nebenan-ui-kit": "^5.1.0",
         "node-sass-glob-importer": "^5.3.2",
         "prop-types": "^15.7.2",
         "qs": "^6.9.4",
@@ -45,7 +45,7 @@
         "nebenan-form": "^8.9.0 || ^9.0.0",
         "nebenan-helpers": "^4.6.0 || ^5.0.0",
         "nebenan-react-hocs": "^7.1.0 || ^8.0.0",
-        "nebenan-ui-kit": "^4.17.0 || ^5.0.0",
+        "nebenan-ui-kit": "^5.1.0",
         "prop-types": "^15.7.2",
         "react": "^16.14.0 || ^17.0.1",
         "react-load-script": "^0.0.6",
@@ -1561,9 +1561,9 @@
       }
     },
     "node_modules/nebenan-ui-kit": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/nebenan-ui-kit/-/nebenan-ui-kit-5.0.1.tgz",
-      "integrity": "sha512-s/9t3OBTI7tRaSkAx2yatq6VsPO9OIip8YkXD3vzbeMDxcCBIMVsKFkpHiehRtBfHS51xog2Zw0BAkRULrnSrw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/nebenan-ui-kit/-/nebenan-ui-kit-5.1.0.tgz",
+      "integrity": "sha512-saexp/BFhSz1FKBbQqR+vVNTQonoAeUZfUERIrSOemklyzDSpCncg3twkJdaNzX7QFpnsEZ950PsRj8lBbA5xA==",
       "dev": true,
       "dependencies": {
         "@fontsource/open-sans": "^4.1.0",
@@ -4020,9 +4020,9 @@
       "requires": {}
     },
     "nebenan-ui-kit": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/nebenan-ui-kit/-/nebenan-ui-kit-5.0.1.tgz",
-      "integrity": "sha512-s/9t3OBTI7tRaSkAx2yatq6VsPO9OIip8YkXD3vzbeMDxcCBIMVsKFkpHiehRtBfHS51xog2Zw0BAkRULrnSrw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/nebenan-ui-kit/-/nebenan-ui-kit-5.1.0.tgz",
+      "integrity": "sha512-saexp/BFhSz1FKBbQqR+vVNTQonoAeUZfUERIrSOemklyzDSpCncg3twkJdaNzX7QFpnsEZ950PsRj8lBbA5xA==",
       "dev": true,
       "requires": {
         "@fontsource/open-sans": "^4.1.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -11,7 +11,7 @@
   "bugs": {
     "url": "https://github.com/goodhood-eu/goodhood/issues"
   },
-  "version": "5.0.0",
+  "version": "5.1.0",
   "module": "lib/index.esm.js",
   "main": "lib/index.js",
   "sideEffects": false,
@@ -32,7 +32,7 @@
     "nebenan-form": "^9.0.0",
     "nebenan-helpers": "^5.0.0",
     "nebenan-react-hocs": "^8.0.0",
-    "nebenan-ui-kit": "^5.0.1",
+    "nebenan-ui-kit": "^5.1.0",
     "node-sass-glob-importer": "^5.3.2",
     "prop-types": "^15.7.2",
     "qs": "^6.9.4",

--- a/packages/components/src/cookies_banner/index.module.scss
+++ b/packages/components/src/cookies_banner/index.module.scss
@@ -6,7 +6,7 @@
   position: fixed;
   bottom: 0;
   left: 0;
-  z-index: $z-modal;
+  z-index: $z-modal-banner;
   background-color: $color-dark-alpha;
   font-size: 12px;
   color: $color-gray-07;


### PR DESCRIPTION
@goodhood/components nebenan-ui-kit peer dep may not need to be updated since the variables are used during compile time. We may only need to update the peer dep if are using new css classes or maybe rely on updated styles(?)