### PR TITLE
Fix modal close compatibility by calling the done callback

### DIFF
--- a/packages/modals/package.json
+++ b/packages/modals/package.json
@@ -11,7 +11,7 @@
   "bugs": {
     "url": "https://github.com/goodhood-eu/goodhood/issues"
   },
-  "version": "0.3.0",
+  "version": "0.3.1",
   "module": "lib/index.esm.js",
   "main": "lib/index.js",
   "sideEffects": false,

--- a/packages/modals/src/modal/hooks.jsx
+++ b/packages/modals/src/modal/hooks.jsx
@@ -44,7 +44,12 @@ export const useKeyManager = (onClose) => (
 
 export const useLegacyHandle = (ref, containerRef, onClose) => (
   useImperativeHandle(ref, () => ({
-    close: () => invoke(onClose),
+    close: (done) => {
+      // simulate calling done after modal is closed
+      setTimeout(() => invoke(done));
+
+      return invoke(onClose);
+    },
     getNode: () => containerRef.current,
   }), [containerRef.current, onClose])
 );


### PR DESCRIPTION
Related: https://jira.nebenan.de/browse/CORE-8017

In many cases of our apps we use `modal.close(done)` to open up more modals or do other stuff. We forgot to support `done` in our compatibility layer. With this change it should hopefully work but it will get difficult with async stuff happening in onClose

- [x] QA approved CORE-8017
- [x] Non-beta version published
- [ ] Updated in CoreFE
- [ ] Updated in BizFE