### PR TITLE
Modals: Fix missing width limitation in non-scrollable modals

### DIFF
--- a/packages/modals/package.json
+++ b/packages/modals/package.json
@@ -11,7 +11,7 @@
   "bugs": {
     "url": "https://github.com/goodhood-eu/goodhood/issues"
   },
-  "version": "0.4.2",
+  "version": "0.4.4-beta.0",
   "module": "lib/index.esm.js",
   "main": "lib/index.js",
   "sideEffects": false,

--- a/packages/modals/src/modal/index.module.scss
+++ b/packages/modals/src/modal/index.module.scss
@@ -60,9 +60,11 @@
 .content {
   display: grid;
   grid-template-rows: minmax(0, 1fr);
+  grid-template-columns: minmax(0, 1fr);
 
   .isScrollable & {
     grid-template-rows: 1fr;
+    grid-template-columns: 1fr;
     overflow: auto;
   }
 }

--- a/packages/modals/src/modal/index.stories.jsx
+++ b/packages/modals/src/modal/index.stories.jsx
@@ -12,7 +12,7 @@ export const Default = () => {
   const staticPosition = boolean('Static position', false);
   const persist = boolean('Persist', false);
   const unmountAction = action('Unmount');
-  const withLongContent = boolean('Long Content', false);
+  const scrollable = boolean('Scrollable', true);
 
   return (
     <ModalProvider>
@@ -20,20 +20,39 @@ export const Default = () => {
 
       {isActive && (
         <Modal
-          {...{ staticPosition, persist }}
+          {...{ staticPosition, persist, scrollable }}
           onClose={() => setActive(false)}
           onUnmount={unmountAction}
         >
-          {!withLongContent && (
-            <div className="ui-card">
-              Hello world
-            </div>
-          )}
-          {withLongContent && (
-            <div className="ui-card">
-              <img className={styles.img} src="https://longc.at/longcat.jpg" alt="" />
-            </div>
-          )}
+          <div className="ui-card">
+            Hello world
+          </div>
+        </Modal>
+      )}
+    </ModalProvider>
+  );
+};
+
+export const LongAndScrollable = () => {
+  const [isActive, setActive] = useState();
+  const staticPosition = boolean('Static position', false);
+  const persist = boolean('Persist', false);
+  const unmountAction = action('Unmount');
+  const scrollable = boolean('Scrollable', true);
+
+  return (
+    <ModalProvider>
+      <span onClick={() => setActive(true)}>Open Modal</span>
+
+      {isActive && (
+        <Modal
+          {...{ staticPosition, persist, scrollable }}
+          onClose={() => setActive(false)}
+          onUnmount={unmountAction}
+        >
+          <div className="ui-card">
+            <img className={styles.img} src="https://longc.at/longcat.jpg" alt="" />
+          </div>
         </Modal>
       )}
     </ModalProvider>


### PR DESCRIPTION
Previously we only set grid rows, therefore limiting the box size.

We forgot about setting a column, therefore there was no limit on box size (it adjusted to the content).