### PR TITLE
Components: Fix SideScroller animation executing after unmount

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -11,7 +11,7 @@
   "bugs": {
     "url": "https://github.com/goodhood-eu/goodhood/issues"
   },
-  "version": "6.6.1",
+  "version": "6.6.2",
   "module": "lib/index.esm.js",
   "main": "lib/index.js",
   "sideEffects": false,

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -11,7 +11,7 @@
   "bugs": {
     "url": "https://github.com/goodhood-eu/goodhood/issues"
   },
-  "version": "7.0.0",
+  "version": "7.0.1",
   "module": "lib/index.esm.js",
   "main": "lib/index.js",
   "sideEffects": false,

--- a/packages/components/src/side_scroller/index.jsx
+++ b/packages/components/src/side_scroller/index.jsx
@@ -10,6 +10,7 @@ import Draggable from '../draggable';
 import Controls from './controls';
 import { DISABLE_SCROLL_DISTANCE, SHIFT_PERCENT, SHIFT_TOLERANCE, ANIMATION_DURATION, ANIMATION_FPS } from './constants';
 import { getAnimationPosition } from './utils';
+import useMounted from 'nebenan-react-hocs/lib/use_mounted';
 
 const SideScroller = ({
   className: passedClassName,
@@ -20,6 +21,8 @@ const SideScroller = ({
   const [canScrollLeft, setCanScrollLeft] = useState(false);
   const [canScrollRight, setCanScrollRight] = useState(false);
   const [height, setHeight] = useState(0);
+
+  const isMounted = useMounted();
 
   const containerRef = useRef(null);
   const contentRef = useRef(null);
@@ -107,6 +110,8 @@ const SideScroller = ({
     let time = 0;
 
     const animateScroll = () => {
+      if (!isMounted.current) return;
+
       const newValue = getAnimationPosition(
         containerRef.current.scrollLeft,
         target,


### PR DESCRIPTION
https://sentry.nebenan.de/organizations/sentry/issues/38/events/oldest/?project=4&query=is%3Aunresolved&sort=freq&statsPeriod=14d

How to reproduce:
- [Set animation duration to a very high value](https://github.com/goodhood-eu/goodhood/blob/3477b5e32fc84d504f506e0837c35caff4c09d24/packages/components/src/side_scroller/constants.jsx#L6)
- Visit SideScroller preview
- Click the left arrow
- While the animation is still ongoing, visit another story (needs proper timing but works pretty often)
- -> Crash `Cannot read properties of null (reading 'scrollLeft')`
