### PR TITLE
Goodhood: Add ClickAway component 

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -11,7 +11,7 @@
   "bugs": {
     "url": "https://github.com/goodhood-eu/goodhood/issues"
   },
-  "version": "7.1.0",
+  "version": "7.2.0",
   "module": "lib/index.esm.js",
   "main": "lib/index.js",
   "sideEffects": false,

--- a/packages/components/src/click_away/index.jsx
+++ b/packages/components/src/click_away/index.jsx
@@ -1,0 +1,73 @@
+import { createContext, useCallback, useContext, useEffect, useRef } from 'react';
+
+const context = createContext(() => {
+  throw new Error('ClickAwayProvider not set up');
+});
+
+export const ClickAwayProvider = ({ children, ...rest }) => {
+  const isInnerClickMapRef = useRef(new Map());
+  const clickAwayHandlersRef = useRef(new Map());
+
+  const handleClick = () => {
+    const innerClickMap = isInnerClickMapRef.current;
+    const handlersMap = clickAwayHandlersRef.current;
+
+    innerClickMap.forEach((isInnerClick, id) => {
+      if (isInnerClick) return;
+
+      handlersMap.get(id)();
+    });
+
+    innerClickMap.forEach((_, id) => {
+      innerClickMap.set(id, false);
+    });
+  };
+
+  const register = useCallback((onClickAway) => {
+    const innerClickMap = isInnerClickMapRef.current;
+    const handlersMap = clickAwayHandlersRef.current;
+
+    const id = Symbol('listener id');
+
+    handlersMap.set(id, onClickAway);
+    innerClickMap.set(id, false);
+
+    const unregister = () => {
+      clickAwayHandlersRef.current.delete(id);
+      innerClickMap.delete(id);
+    };
+
+    const onInnerClick = () => {
+      innerClickMap.set(id, true);
+    };
+
+    return { unregister, onInnerClick };
+  }, []);
+
+  return (
+    <context.Provider value={register}>
+      <div {...rest} onClick={handleClick}>{children}</div>
+    </context.Provider>
+  );
+};
+
+/**
+ * @param onClickAway function to be called when user clicks outside the 'inner element'
+ * @returns {(function(): void)|*} click handler that needs to be attached to the 'inner element'
+ */
+export const useClickAway = (onClickAway) => {
+  const register = useContext(context);
+  const onInnerClickRef = useRef(null);
+
+  useEffect(() => {
+    const { unregister, onInnerClick } = register(onClickAway);
+
+    onInnerClickRef.current = onInnerClick;
+
+    return unregister;
+  }, [onClickAway]);
+
+  return useCallback(() => {
+    onInnerClickRef.current?.();
+  }, []);
+};

--- a/packages/components/src/click_away/index.stories.jsx
+++ b/packages/components/src/click_away/index.stories.jsx
@@ -1,0 +1,34 @@
+import { ClickAwayProvider, useClickAway } from '@/src/click_away/index';
+import { action } from '@root/.preview/src/modules/actions';
+
+export default { title: 'ClickAway', component: ClickAwayProvider };
+
+
+const Demo = () => {
+  const onInnerClick = useClickAway(action('you clicked outside the inner element'));
+  const onInnerInnerClick = useClickAway(action('you clicked outside the inner inner element'));
+
+  return (
+    <article>
+      Click around and check the console!<br />
+      This is the root element
+      <div onClick={onInnerClick}>
+        This is the inner element
+
+        <div onClick={onInnerInnerClick}>
+          This is the inner inner element
+        </div>
+      </div>
+    </article>
+  );
+};
+
+export const Default = () => (
+  <ClickAwayProvider>
+    <Demo />
+  </ClickAwayProvider>
+);
+
+export const NoProviderSetup = () => (
+  <Demo />
+);


### PR DESCRIPTION
Extracted from https://github.com/good-hood-gmbh/business-frontend/pull/596 

Previously we always used `eventproxy('click', cb)` to do outside clicks but it doesn't work inside react portal because of the order of how events are propagated. That's why we have to go the react-only route to check for outside clicks.

Please note that we currently don't gurantee the order in which outslide click handlers are being called. Might need to be changed in the future.