### PR TITLE
[CORE-9919] Migrate progress bar from nebenan components

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -11,7 +11,7 @@
   "bugs": {
     "url": "https://github.com/goodhood-eu/goodhood/issues"
   },
-  "version": "7.3.0-beta.0",
+  "version": "7.3.0-beta.1",
   "module": "lib/index.esm.js",
   "main": "lib/index.js",
   "sideEffects": false,

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -11,7 +11,7 @@
   "bugs": {
     "url": "https://github.com/goodhood-eu/goodhood/issues"
   },
-  "version": "7.3.0-beta.1",
+  "version": "7.3.0",
   "module": "lib/index.esm.js",
   "main": "lib/index.js",
   "sideEffects": false,

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -11,7 +11,7 @@
   "bugs": {
     "url": "https://github.com/goodhood-eu/goodhood/issues"
   },
-  "version": "7.2.1",
+  "version": "7.3.0-beta.0",
   "module": "lib/index.esm.js",
   "main": "lib/index.js",
   "sideEffects": false,

--- a/packages/components/src/progress_bar/index.jsx
+++ b/packages/components/src/progress_bar/index.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { getPercentage } from './utils';
+import { getPercentageString } from './utils';
 import styles from './index.module.scss';
 
 const ProgressBar = ({
@@ -11,7 +11,7 @@ const ProgressBar = ({
   progressBarProgressIndicatorStyles,
   ...cleanProps
 }) => {
-  const percent = getPercentage(state);
+  const percent = getPercentageString(state);
 
   const className = clsx(styles.root, progressBarStyles, {
     [styles.small]: size === 'small',
@@ -23,7 +23,7 @@ const ProgressBar = ({
         className={clsx(styles.progressState, progressBarProgressIndicatorStyles)}
         style={{ width: percent }}
       >
-        <em>{percent}</em>
+        <em className={styles.percent}>{percent}</em>
       </span>
       {children}
     </div>

--- a/packages/components/src/progress_bar/index.jsx
+++ b/packages/components/src/progress_bar/index.jsx
@@ -10,7 +10,6 @@ const ProgressBar = ({
   state,
   size,
   theme = PROGRESS_BAR_THEME_MODERN,
-  ...cleanProps
 }) => {
   const percent = getPercentageString(state);
 
@@ -19,7 +18,7 @@ const ProgressBar = ({
   });
 
   return (
-    <div {...cleanProps} className={className}>
+    <div className={className}>
       <span
         className={clsx(styles.progressState, styles[`theme-${theme}`])}
         style={{ width: percent }}

--- a/packages/components/src/progress_bar/index.jsx
+++ b/packages/components/src/progress_bar/index.jsx
@@ -1,0 +1,44 @@
+import PropTypes from 'prop-types';
+import clsx from 'clsx';
+import { getPercentage } from './utils';
+import styles from './index.module.scss';
+
+const ProgressBar = ({
+  state,
+  size,
+  children,
+  progressBarStyles,
+  progressBarProgressIndicatorStyles,
+  ...cleanProps
+}) => {
+  const percent = getPercentage(state);
+
+  const className = clsx(styles.root, progressBarStyles, {
+    [styles.small]: size === 'small',
+  });
+
+  return (
+    <div {...cleanProps} className={className}>
+      <span
+        className={clsx(styles.progressState, progressBarProgressIndicatorStyles)}
+        style={{ width: percent }}
+      >
+        <em>{percent}</em>
+      </span>
+      {children}
+    </div>
+  );
+};
+
+ProgressBar.propTypes = {
+  progressBarStyles: PropTypes.string,
+  progressBarProgressIndicatorStyles: PropTypes.string,
+  state: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number,
+  ]),
+  size: PropTypes.string,
+  children: PropTypes.node,
+};
+
+export default ProgressBar;

--- a/packages/components/src/progress_bar/index.jsx
+++ b/packages/components/src/progress_bar/index.jsx
@@ -3,13 +3,13 @@ import clsx from 'clsx';
 import { getPercentageString } from './utils';
 import styles from './index.module.scss';
 
-export const THEME_MODERN = 'modern';
+export const PROGRESS_BAR_THEME_MODERN = 'modern';
+export const PROGRESS_BAR_THEME_LEGACY = 'legacy';
 
 const ProgressBar = ({
   state,
   size,
-  children,
-  theme = THEME_MODERN,
+  theme = PROGRESS_BAR_THEME_MODERN,
   ...cleanProps
 }) => {
   const percent = getPercentageString(state);
@@ -26,21 +26,17 @@ const ProgressBar = ({
       >
         <em className={styles.percent}>{percent}</em>
       </span>
-      {children}
     </div>
   );
 };
 
 ProgressBar.propTypes = {
-  progressBarStyles: PropTypes.string,
-  progressBarProgressIndicatorStyles: PropTypes.string,
   state: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.number,
   ]),
   size: PropTypes.string,
-  children: PropTypes.node,
-  theme: PropTypes.object,
+  theme: PropTypes.string,
 };
 
 export default ProgressBar;

--- a/packages/components/src/progress_bar/index.jsx
+++ b/packages/components/src/progress_bar/index.jsx
@@ -3,24 +3,25 @@ import clsx from 'clsx';
 import { getPercentageString } from './utils';
 import styles from './index.module.scss';
 
+export const THEME_MODERN = 'modern';
+
 const ProgressBar = ({
   state,
   size,
   children,
-  progressBarStyles,
-  progressBarProgressIndicatorStyles,
+  theme = THEME_MODERN,
   ...cleanProps
 }) => {
   const percent = getPercentageString(state);
 
-  const className = clsx(styles.root, progressBarStyles, {
+  const className = clsx(styles.root, styles[`theme-${theme}`], {
     [styles.small]: size === 'small',
   });
 
   return (
     <div {...cleanProps} className={className}>
       <span
-        className={clsx(styles.progressState, progressBarProgressIndicatorStyles)}
+        className={clsx(styles.progressState, styles[`theme-${theme}`])}
         style={{ width: percent }}
       >
         <em className={styles.percent}>{percent}</em>
@@ -39,6 +40,7 @@ ProgressBar.propTypes = {
   ]),
   size: PropTypes.string,
   children: PropTypes.node,
+  theme: PropTypes.object,
 };
 
 export default ProgressBar;

--- a/packages/components/src/progress_bar/index.module.scss
+++ b/packages/components/src/progress_bar/index.module.scss
@@ -23,11 +23,11 @@
   left: 0;
 
   transition: width $transition;
+}
 
-  em {
-    padding: 0 5px;
-    font-style: normal;
-  }
+.percent {
+  padding: 0 5px;
+  font-style: normal;
 }
 
 .small {

--- a/packages/components/src/progress_bar/index.module.scss
+++ b/packages/components/src/progress_bar/index.module.scss
@@ -1,0 +1,40 @@
+@import "nebenan-ui-kit";
+
+.root {
+  height: 20px;
+
+  overflow: hidden;
+  position: relative;
+
+  border-radius: $border-radius-m;
+  background: $color-gray-05;
+
+  color: $color-gray-09;
+  font-size: $font-size-s;
+  line-height: 20px;
+  text-align: right;
+}
+
+.progressState {
+  height: 100%;
+  position: absolute;
+  background: $color-green-02;
+  top: 0;
+  left: 0;
+
+  transition: width $transition;
+
+  em {
+    padding: 0 5px;
+    font-style: normal;
+  }
+}
+
+.small {
+  height: 10px;
+  border-radius: 5px;
+
+  .progressState {
+    @include text-invisible;
+  }
+}

--- a/packages/components/src/progress_bar/index.module.scss
+++ b/packages/components/src/progress_bar/index.module.scss
@@ -6,23 +6,38 @@
   overflow: hidden;
   position: relative;
 
-  border-radius: $border-radius-m;
-  background: $color-gray-05;
-
   color: $color-gray-09;
   font-size: $font-size-s;
   line-height: 20px;
   text-align: right;
+
+  &.theme-modern {
+    border-radius: 8px;
+    background: $color-blue-03;
+  }
+
+  &.theme-legacy {
+    border-radius: $border-radius-m;
+    background: $color-gray-05;
+  }
 }
 
 .progressState {
   height: 100%;
   position: absolute;
-  background: $color-green-02;
   top: 0;
   left: 0;
 
   transition: width $transition;
+
+  &.theme-modern {
+    background: linear-gradient(90deg, #008291 0%, #33a6b4 100%);
+    border-radius: 8px;
+  }
+
+  &.theme-legacy {
+    background: $color-green-02;
+  }
 }
 
 .percent {

--- a/packages/components/src/progress_bar/index.stories.jsx
+++ b/packages/components/src/progress_bar/index.stories.jsx
@@ -1,4 +1,4 @@
-import ProgressBar from './index';
+import ProgressBar, { PROGRESS_BAR_THEME_LEGACY } from './index';
 
 export default { title: 'ProgressBar', component: ProgressBar };
 
@@ -6,4 +6,4 @@ export const Default = () => <ProgressBar state={55} />;
 
 export const Small = () => <ProgressBar state={34} size="small" />;
 
-export const Legacy = () => <ProgressBar state={77} theme="legacy" />;
+export const Legacy = () => <ProgressBar state={77} theme={PROGRESS_BAR_THEME_LEGACY} />;

--- a/packages/components/src/progress_bar/index.stories.jsx
+++ b/packages/components/src/progress_bar/index.stories.jsx
@@ -1,18 +1,9 @@
 import ProgressBar from './index';
-import styles from './index.stories.module.scss';
 
 export default { title: 'ProgressBar', component: ProgressBar };
 
 export const Default = () => <ProgressBar state={55} />;
 
-
 export const Small = () => <ProgressBar state={34} size="small" />;
 
-export const CustomStyles = () => (
-  <ProgressBar
-    progressBarStyles={styles.progressBarStyles}
-    progressBarProgressIndicatorStyles={styles.progressBarProgressIndicatorStyles}
-    state={77}
-    size="small"
-  />
-);
+export const Legacy = () => <ProgressBar state={77} theme="legacy" />;

--- a/packages/components/src/progress_bar/index.stories.jsx
+++ b/packages/components/src/progress_bar/index.stories.jsx
@@ -1,0 +1,18 @@
+import ProgressBar from './index';
+import styles from './index.stories.module.scss';
+
+export default { title: 'ProgressBar', component: ProgressBar };
+
+export const Default = () => <ProgressBar state={55} />;
+
+
+export const Small = () => <ProgressBar state={34} size="small" />;
+
+export const CustomStyles = () => (
+  <ProgressBar
+    progressBarStyles={styles.progressBarStyles}
+    progressBarProgressIndicatorStyles={styles.progressBarProgressIndicatorStyles}
+    state={77}
+    size="small"
+  />
+);

--- a/packages/components/src/progress_bar/index.stories.module.scss
+++ b/packages/components/src/progress_bar/index.stories.module.scss
@@ -1,0 +1,8 @@
+.progressBarStyles {
+  background: #e5f3f5;
+}
+
+.progressBarProgressIndicatorStyles {
+  background: linear-gradient(90deg, #008291 0%, #33a6b4 100%);
+  border-radius: 8px;
+}

--- a/packages/components/src/progress_bar/index.stories.module.scss
+++ b/packages/components/src/progress_bar/index.stories.module.scss
@@ -1,8 +1,0 @@
-.progressBarStyles {
-  background: #e5f3f5;
-}
-
-.progressBarProgressIndicatorStyles {
-  background: linear-gradient(90deg, #008291 0%, #33a6b4 100%);
-  border-radius: 8px;
-}

--- a/packages/components/src/progress_bar/utils.jsx
+++ b/packages/components/src/progress_bar/utils.jsx
@@ -1,0 +1,9 @@
+export const getPercentage = (input) => {
+  let percent;
+  if (typeof input === 'number' && input < 1) percent = String(input * 100);
+  else percent = String(input);
+
+  if (!percent.includes('%')) percent = `${percent}%`;
+
+  return percent;
+};

--- a/packages/components/src/progress_bar/utils.jsx
+++ b/packages/components/src/progress_bar/utils.jsx
@@ -1,9 +1,5 @@
-export const getPercentage = (input) => {
-  let percent;
-  if (typeof input === 'number' && input < 1) percent = String(input * 100);
-  else percent = String(input);
-
-  if (!percent.includes('%')) percent = `${percent}%`;
-
-  return percent;
+export const getPercentageString = (input) => {
+  if (typeof input === 'number' && input < 1) return `${input}%`;
+  if (`${input}`.includes('%')) return `${input}`;
+  return `${input}%`;
 };

--- a/packages/components/src/progress_bar/utils.test.jsx
+++ b/packages/components/src/progress_bar/utils.test.jsx
@@ -1,0 +1,16 @@
+import { assert } from 'chai';
+import { getPercentageString } from './utils';
+
+describe('progress_bar', () => {
+  describe('getPercentageString', () => {
+    it('returns the number concatinated with a percentage', () => {
+      assert.deepEqual(getPercentageString(45), '45%', 'regular case');
+    });
+    it('returns the number concatinated with a percentage', () => {
+      assert.deepEqual(getPercentageString('45'), '45%', 'regular case');
+    });
+    it('returns the number concatinated with a percentage', () => {
+      assert.deepEqual(getPercentageString('45%'), '45%', 'regular case');
+    });
+  });
+});


### PR DESCRIPTION
I want to migrate the old progress bar from nebenan components. 
Mainly because I want to make it more customizable, meaning I am able to style the background color of the bar and the progress indicator bar in the foreground independent from each other in an easy way. 
Functionality stays (nearly) the same, but instead of passing a "type" prop, I want to pass 2 className props, which can style the 2 progress bars to make it more flexibel.

