### PR TITLE
inputs-minimal: Prevent label selection in inputs

### DIFF
--- a/packages/inputs-minimal/src/radio/index.module.scss
+++ b/packages/inputs-minimal/src/radio/index.module.scss
@@ -61,6 +61,7 @@
   line-height: 22px;
   color: $color-gray-02;
   font-size: $font-size-m;
+  user-select: none;
 
   &.checked {
     color: $color-gray-00;

--- a/packages/inputs-minimal/src/select/index.module.scss
+++ b/packages/inputs-minimal/src/select/index.module.scss
@@ -55,6 +55,8 @@
   transition: all .2s ease;
   font-size: $heading-size-4;
   font-weight: $font-weight-l;
+  user-select: none;
+  cursor: auto;
 
   &.small,
   &.medium {

--- a/packages/inputs-minimal/src/textarea/index.module.scss
+++ b/packages/inputs-minimal/src/textarea/index.module.scss
@@ -44,6 +44,8 @@
   transition: all .2s ease;
   font-size: $heading-size-4;
   font-weight: $font-weight-l;
+  cursor: auto;
+  user-select: none;
 
   &.focus {
     transform: translateY(-12px);

--- a/packages/inputs-minimal/src/textfield/index.module.scss
+++ b/packages/inputs-minimal/src/textfield/index.module.scss
@@ -73,6 +73,7 @@
   color: $color-gray-03;
   font-size: $font-size-m;
   transition: all .2s ease;
+  user-select: none;
 
   &.large {
     font-size: $heading-size-4;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1128,19 +1128,6 @@
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"
   integrity sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==
 
-"@goodhood/components@^7.0.0":
-  version "7.3.0"
-  resolved "https://registry.yarnpkg.com/@goodhood/components/-/components-7.3.0.tgz#58ff83c8f68753a000c9122e33e5827c56a416df"
-  integrity sha512-gst0n6tx/4vSWS3IBxEZCz/5PR4mOXMWEvNNlYN3DmIDKIV5pREYOQMIUfef2uAY6OLrmjHZcz+oIyoHMHrkLA==
-  dependencies:
-    "@goodhood/icons" "^3.0.0"
-    "@popperjs/core" "^2.5.4"
-    clsx "^1.1.1"
-    escape-html "^1.0.3"
-    lodash "^4.17.20"
-    marked "^4.0.0"
-    nebenan-react-hocs "^9.0.0"
-
 "@goodhood/icons@^2.0.0":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@goodhood/icons/-/icons-2.2.0.tgz#77d5eb6f5d656518f457f895eca892080ea0bc69"


### PR DESCRIPTION
Text selection shouldn't work on inputs labels.

Please check in preview if it really works. Didn't update versions because it's a very small change and not really important. Just noticed it on my own.