### PR TITLE
Keep default mapbox link styles

### DIFF
--- a/packages/map/package.json
+++ b/packages/map/package.json
@@ -11,7 +11,7 @@
   "bugs": {
     "url": "https://github.com/goodhood-eu/goodhood/issues"
   },
-  "version": "7.1.0",
+  "version": "7.1.1",
   "module": "lib/index.esm.js",
   "main": "lib/index.js",
   "sideEffects": false,

--- a/packages/map/src/map/index.module.scss
+++ b/packages/map/src/map/index.module.scss
@@ -16,7 +16,7 @@
     // overrides mapbox z-index
     z-index: 1;
 
-    // keep default mapbox link styles under any circumstances
+    // To prevent global link styles from overwriting, set default styles explicitly
     a {
       color: #000;
       opacity: .7;

--- a/packages/map/src/map/index.module.scss
+++ b/packages/map/src/map/index.module.scss
@@ -16,16 +16,9 @@
     // overrides mapbox z-index
     z-index: 1;
 
-    // To prevent global link styles from overwriting, set default styles explicitly
+    // To prevent global link styles from overwriting
     a {
-      color: #000;
-      opacity: .7;
-      text-decoration: none;
-    }
-    a:hover {
-      color: inherit;
-      text-decoration: underline;
-      text-decoration-color: #777777;
+      all: unset;
     }
   }
 

--- a/packages/map/src/map/index.module.scss
+++ b/packages/map/src/map/index.module.scss
@@ -20,6 +20,9 @@
     a {
       all: unset;
     }
+    a:hover {
+      all: unset;
+    }
   }
 
   :global(.mapboxgl-canvas-container) {

--- a/packages/map/src/map/index.module.scss
+++ b/packages/map/src/map/index.module.scss
@@ -15,6 +15,18 @@
   :global(.mapboxgl-ctrl-bottom-right) {
     // overrides mapbox z-index
     z-index: 1;
+
+    // keep default mapbox link styles under any circumstances
+    a {
+      color: #000;
+      opacity: .7;
+      text-decoration: none;
+    }
+    a:hover {
+      color: inherit;
+      text-decoration: underline;
+      text-decoration-color: #777777;
+    }
   }
 
   :global(.mapboxgl-canvas-container) {

--- a/packages/map/src/map/index.module.scss
+++ b/packages/map/src/map/index.module.scss
@@ -20,6 +20,7 @@
     a {
       all: unset;
     }
+
     a:hover {
       all: unset;
     }


### PR DESCRIPTION
To prevent global link styles from overwriting mapbox links, we need to set them in there.

Issue: https://miro.com/app/board/uXjVO6lyWnY=/?moveToWidget=3458764540076530305&cot=14