### PR TITLE
[CORE-11894] Add support of data-testId in ecosystem bar items

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -11,7 +11,7 @@
   "bugs": {
     "url": "https://github.com/goodhood-eu/goodhood/issues"
   },
-  "version": "7.7.0",
+  "version": "7.7.1",
   "module": "lib/index.esm.js",
   "main": "lib/index.js",
   "types": "lib/types/packages/components/src",

--- a/packages/components/src/ecosystem_bar/index.tsx
+++ b/packages/components/src/ecosystem_bar/index.tsx
@@ -12,6 +12,7 @@ type EcosystemBarItem = {
     mobile: string,
     others: string,
   },
+  testId?: string,
 };
 
 type EcosystemBarProps = {
@@ -34,6 +35,7 @@ export const EcosystemBar = ({ items, onFirstSwipe, onItemClick }: EcosystemBarP
         rel="noreferrer noopener"
         target={item.isActive ? '_self' : '_blank'}
         onClick={() => onItemClick(item.event)}
+        data-testid={item.testId}
       >
         <span className={styles.onlyMobile}>
           {item.text.mobile}


### PR DESCRIPTION
[JIRA Link](https://jira.nebenan.de/browse/CORE-11894)

In order to make the items in the ecosystem bar accessible via data-testid selectors, we need to support such data attributes in the specification and rendering of the ecosystem navbar items.