### PR TITLE
Fix type definition in modal package

### DIFF
--- a/packages/modals/package.json
+++ b/packages/modals/package.json
@@ -27,7 +27,7 @@
     "lint:typescript": "../../scripts/check-typescript"
   },
   "dependencies": {
-    "@goodhood/icons": "^5.0.1",
+    "@goodhood/icons": "^5.1.0",
     "clsx": "^1.2.1",
     "nebenan-helpers": "^7.2.1"
   },

--- a/packages/modals/package.json
+++ b/packages/modals/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://github.com/goodhood-eu/goodhood/packages/modals#readme",
   "repository": "github:goodhood-eu/goodhood",
   "bugs": "https://github.com/goodhood-eu/goodhood/issues",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "module": "lib/index.esm.js",
   "main": "lib/index.js",
   "types": "lib/types/packages/modals/src",

--- a/packages/modals/src/confirm/index.tsx
+++ b/packages/modals/src/confirm/index.tsx
@@ -4,8 +4,8 @@ import { Markdown } from '@goodhood/components';
 import { Modal, ModalProps, ModalRef } from '../modal';
 
 export interface ConfirmProps extends ModalProps {
-  inverted: boolean;
-  locked: boolean;
+  inverted?: boolean;
+  locked?: boolean;
   content?: string;
   title?: string;
   button?: ReactNode;


### PR DESCRIPTION
locked and inverted can be optional since they have default values